### PR TITLE
Arguments with validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ module Users
     # So, we define on fail callback where we copy errors from model
     # to service so now in controller we can check and use only service's errors
 
-    on_fail { errors! user.errors(u.errors.to_h) }
+    on_fail { errors! user.errors.to_h }
   end
 end
 

--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -1,20 +1,28 @@
 require 'performify/callbacks'
+require 'performify/validation'
 
 module Performify
   class Base
     extend Performify::Callbacks
+    extend Performify::Validation
 
     attr_reader :current_user
 
     def initialize(current_user = nil, **args)
       @current_user = current_user
 
-      args.each do |arg_name, arg_value|
+      return if args.empty?
+
+      validate(args).each do |arg_name, arg_value|
         define_singleton_method(arg_name) { arg_value }
       end
+
+      fail!(with_callbacks: true) if errors?
     end
 
     def execute!
+      return if defined?(@result)
+
       block_result = nil
 
       ActiveRecord::Base.transaction do

--- a/lib/performify/validation.rb
+++ b/lib/performify/validation.rb
@@ -1,0 +1,42 @@
+require 'dry-validation'
+
+module Performify
+  module Validation
+    def self.extended(base)
+      base.extend Performify::Validation::ClassMethods
+      base.include Performify::Validation::InstanceMethods
+    end
+
+    module ClassMethods
+      def schema(&block)
+        return @schema unless block_given?
+        @schema = Dry::Validation.Schema(Dry::Validation::Schema::Form, {}, &block)
+      end
+    end
+
+    module InstanceMethods
+      def schema
+        self.class.schema
+      end
+
+      def validate(args)
+        return args if schema.nil?
+        result = schema.call(args)
+        errors!(result.errors) unless result.success?
+        result.output
+      end
+
+      def errors!(new_errors)
+        errors.merge!(new_errors)
+      end
+
+      def errors
+        @errors ||= {}
+      end
+
+      def errors?
+        errors.any?
+      end
+    end
+  end
+end

--- a/performify.gemspec
+++ b/performify.gemspec
@@ -26,10 +26,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", ">= 4.0.0"
+  spec.add_dependency "dry-validation", ">= 0.10.7"
 
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.13"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop", "~> 0.48"
+  spec.add_development_dependency "byebug", "~> 9.0.6"
 end

--- a/spec/lib/performify/execute_spec.rb
+++ b/spec/lib/performify/execute_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe Performify::Base do
         subject.execute! { false }
       end.to yield_control
     end
+
+    context 'when execution has been already performed' do
+      it 'performes execution only once' do
+        expect do |b|
+          subject.execute!(&b)
+        end.to yield_control.exactly(1).times
+      end
+    end
+
+    context 'when execution result is already known' do
+      it 'does not perform execution' do
+        subject.fail!(with_callbacks: false)
+        expect { |b| subject.execute!(&b) }.to yield_control.exactly(0).times
+      end
+    end
   end
 
   describe '#success!' do

--- a/spec/lib/performify/validation_spec.rb
+++ b/spec/lib/performify/validation_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe Performify::Base do
+  let(:user) { double(:user) }
+  let(:args) do
+    {
+      foo: 'bar'
+    }
+  end
+
+  let(:klass) do
+    Class.new(described_class) do
+      schema do
+        required(:foo).filled(:str?)
+      end
+
+      def execute!
+        super { true }
+      end
+    end
+  end
+
+  subject { klass.new(user, **args) }
+
+  after { klass.clean_callbacks }
+
+  describe '#initialize' do
+    it 'validates given args using defined schema without errors' do
+      expect(subject.errors).to be_empty
+    end
+
+    it 'allows to successfully execute without any problems' do
+      subject.execute!
+      expect(subject.success?).to be true
+    end
+
+    context 'when args are invalid' do
+      let(:args) do
+        {
+          foo: nil
+        }
+      end
+
+      it 'validates given args and provides access to errors' do
+        expect(subject.errors).to be_present
+      end
+
+      it 'mark execution as failed even before execution call' do
+        expect(subject.fail?).to be true
+      end
+
+      it 'ignores all attempts of service execution' do
+        subject.execute!
+        expect(subject.success?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Performify allows you to validate input arguments using [dry-validation](http://dry-rb.org/gems/dry-validation/) schemas. Validation is performed on creation of service instance. And if validation is not passed it will be impossible to call execution. Result of execution will be automatically switched to failed state.

```ruby
module Users
  module Create
    schema do
      required(:email).filled(:str?)
    end

    def execute!
      # it will be impossible to call execution if provided arguments
      # did not pass validation
    end
  end
end

service = Users::Create.new(current_user, email: nil)
service.execute! # nothing happens here
service.success? # will be false because of validation
service.errors   # contains hash of errors
```

Sometimes you can have differences between validation errors and execution errors. But usually it's boring to check them separately since you just need to display final result to user. To avoid double check you can use following trick:

```ruby
module Users
  module Create
    attr_reader :user

    schema do
      required(:email).filled(:str?)
    end

    def execute!
      user = User.new(email: email)
      authorize! user

      # Let's assume that user has additional validation of uniqueness on the
      # level of model, so in controller you need to check separately service's
      # errors and model's errors, right?

      super { user.save }
    end

    # So, we define on fail callback where we copy errors from model
    # to service so now in controller we can check and use only service's errors

    on_fail { errors! user.errors(u.errors.to_h) }
  end
end

# in controller

service = Users::Create.new(current_user, email: nil)
service.execute!

if service.success?
  # respond with ok
else
  # respond with unprocessable entity and service.errors
end
```