### PR TITLE
Result should be implicitly checked before execution even if super thod was not called explicitly

### DIFF
--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -26,8 +26,6 @@ module Performify
     end
 
     def execute!
-      return if defined?(@result)
-
       block_result = nil
 
       ActiveRecord::Base.transaction do

--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -11,6 +11,11 @@ module Performify
     def initialize(current_user = nil, **args)
       @current_user = current_user
 
+      define_singleton_method(:execute!) do |&block|
+        return if defined?(@result)
+        super(&block)
+      end
+
       return if args.empty?
 
       validate(args).each do |arg_name, arg_value|

--- a/spec/lib/performify/validation_spec.rb
+++ b/spec/lib/performify/validation_spec.rb
@@ -53,6 +53,25 @@ RSpec.describe Performify::Base do
         subject.execute!
         expect(subject.success?).to be false
       end
+
+      context 'and when execution does not use super' do
+        let(:klass) do
+          Class.new(described_class) do
+            schema do
+              required(:foo).filled(:str?)
+            end
+
+            def execute!
+              success!
+            end
+          end
+        end
+
+        it 'ignores all attempts of service execution' do
+          subject.execute!
+          expect(subject.success?).to be false
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Let's say we have service that has validation for arguments and implements execution without calling to super. Like this:

```ruby
class SomeService < ApplicationService
  schema do
    required(:foo).filled(:str?)
  end
  
  def execute!
    success!
  end
end
```

When we call this service with invalid arguments validation fails and execution should not be performed because provided arguments are invalid:

```ruby
service = SomeService.new(current_user, foo: nil)
service.execute!
service.success? # should be false because of validation errros
```