### PR TITLE
Allow passing of errors to fail

### DIFF
--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -58,8 +58,9 @@ module Performify
       @result
     end
 
-    def fail!(with_callbacks: true)
+    def fail!(with_callbacks: true, errors: nil)
       @result = false
+      errors!(errors) unless errors.nil?
       execute_callbacks if with_callbacks
       @result
     end

--- a/lib/performify/validation.rb
+++ b/lib/performify/validation.rb
@@ -27,7 +27,8 @@ module Performify
       end
 
       def errors!(new_errors)
-        errors.merge!(new_errors)
+        raise ArgumentError, 'Errors should be a hash' if new_errors.nil? || !new_errors.respond_to?(:to_h)
+        errors.merge!(new_errors.to_h)
       end
 
       def errors

--- a/spec/lib/performify/execute_spec.rb
+++ b/spec/lib/performify/execute_spec.rb
@@ -95,6 +95,12 @@ RSpec.describe Performify::Base do
         subject.fail!
       end.not_to yield_control
     end
+
+    it 'stores provided errors' do
+      errors = { foo: 'bar' }
+      subject.fail!(errors: errors)
+      expect(subject.errors).to eq(errors)
+    end
   end
 
   describe '#success?' do

--- a/spec/lib/performify/validation_spec.rb
+++ b/spec/lib/performify/validation_spec.rb
@@ -24,6 +24,39 @@ RSpec.describe Performify::Base do
 
   after { klass.clean_callbacks }
 
+  describe '#errors!' do
+    it 'creates errors hash' do
+      error = { user_id: 'is invalid' }
+      subject.errors!(error)
+      expect(subject.errors).to eq(error)
+    end
+
+    it 'merges new errors to existing hash' do
+      error_1 = { user_id: 'is invalid' }
+      error_2 = { password: 'is too easy' }
+
+      subject.errors!(error_1)
+      subject.errors!(error_2)
+
+      expect(subject.errors).to eq(error_1.merge(error_2))
+    end
+
+    it 'converts argument to hash' do
+      error = [ [:user_id, 'is invalid'] ]
+      subject.errors!(error)
+      expect(subject.errors).to eq(user_id: 'is invalid')
+    end
+
+    it 'raises ArgumentError if argument is nil' do
+      expect { subject.errors!(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'raises ArgumentError if argument is not a hash' do
+      error = 'Very bad situation'
+      expect { subject.errors!(error) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe '#initialize' do
     it 'validates given args using defined schema without errors' do
       expect(subject.errors).to be_empty


### PR DESCRIPTION
Sometimes it's useful to be able to pass errors directly to `fail!` instead of providing it separately. For example, instead of this:

```ruby
class SomeService < ApplicationService
  schema do
    required(:user_id).filled(:int?)
  end  
 
  def execute!
    unless user.present?
      errors!(user_id: 'is invalid')
      fail!
      return
    end
    
    success!
  end

  def user
    @user ||= User.find_by(id: user_id)
  end
end
```

You can do this:

```ruby
class SomeService < ApplicationService
  schema do
    required(:user_id).filled(:int?)
  end  
 
  def execute!
    unless user.present?
      # fail with errors 
      fail!(errors: { user_id: 'is invalid' })
      return
    end
    
    success!
  end

  def user
    @user ||= User.find_by(id: user_id)
  end
end
```